### PR TITLE
fix: device not detected because of late custom device definition loading

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,10 @@ jobs:
         run: |
           bun install
           bun run refresh-kbs
-      - name: Apply patch to device-store.ts
+      - name: Apply patches
         run: |
           sed -i 's|^\(\s*\)//\(.*fetch.*\)|\1\2|; s|^\(\s*\)\(const hash = document.getElementById.*\)|\1//\2|' src/utils/device-store.ts
+          sed -i 's/dispatch(loadStoredCustomDefinitions/await dispatch(loadStoredCustomDefinitions/' src/store/devicesThunks.ts
       - name: Build
         run: bun run build
       - name: Upload artifact

--- a/build-via.sh
+++ b/build-via.sh
@@ -2,6 +2,8 @@ git clone git@github.com:the-via/app via-app
 cd via-app
 npm install
 sed -i 's|^\(\s*\)//\(.*fetch.*\)|\1\2|; s|^\(\s*\)\(const hash = document.getElementById.*\)|\1//\2|' src/utils/device-store.ts
+# Fixes permanent loading issue
+sed -i 's/dispatch(loadStoredCustomDefinitions/await dispatch(loadStoredCustomDefinitions/' src/store/devicesThunks.ts
 npm run build
 
 cp -R dist/ ../public


### PR DESCRIPTION
This fixes an issue (at the least for people with custom device definitions), where their keyboard would not be detected before the via application reloads its connected devices.

Potential fix for #13 