### PR TITLE
Adding Makefile for easier build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: build check clean
+
+build: public/index.html .vite/build/definitions
+	@echo "You can now start the app with:"
+	@echo "npm start"
+
+.vite/build/definitions:
+	mkdir -p .vite/build/definitions
+
+public/index.html: check via-app via-app/src/utils/device-store.ts.old via-app/src/store/devicesThunk.ts.old
+	cd via-app && npm install && npm run build
+	cd via-app && cp -R dist/ ../public
+	npm install
+
+via-app/src/utils/device-store.ts.old:
+	cd via-app && \
+		sed -i.old 's|^\(\s*\)//\(.*fetch.*\)|\1\2|; s|^\(\s*\)\(const hash = document.getElementById.*\)|\1//\2|' src/utils/device-store.ts
+
+via-app/src/store/devicesThunk.ts.old:
+	cd via-app && \
+		sed -i.old 's/dispatch(loadStoredCustomDefinitions/await dispatch(loadStoredCustomDefinitions/' src/store/devicesThunks.ts
+
+via-app:
+	git clone https://github.com/the-via/app via-app
+
+check:
+	which bun || ( echo "You must have bun installed in your PATH for this to work" && exit 1 )
+
+clean:
+	rm -rf via-app public node_modules .vite

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ xattr -d com.apple.quarantine /Users/<me>/Downloads/via-desktop.app
 To start the application, run:
 
 ```sh
-./build-via.sh
-npm install
+make
 npm start
 ```
 


### PR DESCRIPTION
# Rationale

I ran into some issues with the most recent version of via and the included script doesn't actually work anymore. I converted the script to a `Makefile` in order to take advantage of caching and allow build retries without losing the `via-app` dir.

# Benefits

New `make` command allows build restarts, caching, and easy cleanup.